### PR TITLE
メッセージ投稿画面の自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,18 @@
 $(function() {
+
+  // メッセージ投稿機能（非同期通信）の追加用HTML
   function buildHTML(message){
-    let html = `<div class="message">
+    if (message.content && message.image.url) {
+      var contentHtml = message.content
+      var imageHtml = message.image.url
+    } else if (message.content) {
+      var contentHtml = message.content
+      var imageHtml = ""
+    } else if (message.image.url){
+      var contentHtml = ""
+      var imageHtml = message.image.url
+    }
+    let html = `<div class="message" data-id = ${message.id}>
                   <div class="upper-message">
                     <div class="upper-message__user-name">
                     ${message.user_name}
@@ -11,40 +23,25 @@ $(function() {
                   </div>
                   <div class="lower-message">
                     <p class="lower-message__content">
-                    ${message.content}
+                    ${contentHtml}
                     </p>
-                    <img class="lower-message__image" src="${message.image.url}">
+                    <img class="lower-message__image" src=${imageHtml}></img>
                   </div>
                 </div>`
     return html;
   }
 
-  function buildNoImageHTML(message){
-    let html = `<div class="message">
-                  <div class="upper-message">
-                    <div class="upper-message__user-name">
-                    ${message.user_name}
-                    </div>
-                    <div class="upper-message__date">
-                    ${message.created_at}
-                    </div>
-                  </div>
-                  <div class="lower-message">
-                    <p class="lower-message__content">
-                    ${message.content}
-                    </p>
-                  </div>
-                </div>`
-    return html;
-  }
- 
-  function afterSubmit(){
-    $('.new_message')[0].reset();
-    $(".input-box__submit").prop('disabled', false);
+  function autoScroll(){
     let $scrollAuto = $('.messages');
     $scrollAuto.animate({scrollTop: $scrollAuto[0].scrollHeight}, 'slow');
   }
 
+  function SubmitRecovery(){
+    $('.new_message')[0].reset();
+    $(".input-box__submit").prop('disabled', false);
+  }
+
+  // メッセージ投稿機能（非同期通信）
   $("#new_message").on("submit", function(e){
     e.preventDefault();
     let formData = new FormData(this);
@@ -58,22 +55,48 @@ $(function() {
       processData: false,
       contentType: false
     })
-
     .done(function(message){
-      if (message.image.url == null) {
-        let html = buildNoImageHTML(message);
-        $(".messages").append(html);
-        afterSubmit();
-        }
-      else{
         let html = buildHTML(message);
         $(".messages").append(html);
-        afterSubmit();
-        }
-    })
+        SubmitRecovery();
+        autoScroll();
+     })
     .fail(function(){
       alert("error");
-      afterSubmit()
+      SubmitRecovery()
     })
   })
+
+  // 自動更新機能
+  let reloadMessages = function() {
+    let last_message_id = $('.message:last').data('id')  // 表示されているうちで、最新のメッセージのidを変数に代入   
+    let group_page_url = location.href.replace( /messages/g , "" ) 
+    let url = group_page_url +  "api/messages" 
+    $.ajax({
+      url: url,
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0){
+      var insertHTML = "";
+        messages.forEach(function(message){
+        insertHTML = buildHTML(message);
+        $(".messages").append(insertHTML);
+        })
+        autoScroll();
+      }
+    })
+    .fail(function() {
+      alert('自動更新ができません');
+    });
+  };
+
+  // 自動更新をメッセージ投稿画面でのみに限定
+  let cuurrent_page = location.href
+  if (/groups/.test(cuurrent_page) && /messages/.test(cuurrent_page)){
+    setInterval(reloadMessages,7000)
+  }
+
  });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,16 +2,10 @@ $(function() {
 
   // メッセージ投稿機能（非同期通信）の追加用HTML
   function buildHTML(message){
-    if (message.content && message.image.url) {
-      var contentHtml = message.content
-      var imageHtml = message.image.url
-    } else if (message.content) {
-      var contentHtml = message.content
-      var imageHtml = ""
-    } else if (message.image.url){
-      var contentHtml = ""
-      var imageHtml = message.image.url
-    }
+    
+    var contentHtml = message.content ? message.content : '';
+    var imageHtml = message.image.url ? message.image.url : '';
+
     let html = `<div class="message" data-id = ${message.id}>
                   <div class="upper-message">
                     <div class="upper-message__user-name">

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image
+  json.created_at message.created_at.strftime("%Y/%m/%d(%a) %H:%M:%S")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{ data: { id: message.id }}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.content @message.content
 json.created_at @message.created_at.strftime("%Y/%m/%d(%a) %H:%M:%S")
 json.user_name @message.user.name
 json.image @message.image
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#what
メッセージ投稿画面において、自動更新機能を実装するため、以下のコードを追加。
 1.「assets/javascripts/message.js」において、表示済の投稿の中で最新のidを取得し、ajaxを働かせるコードを記述。
 2.名前空間「api」を用い、自動更新機能専用のルーティングを作成。
 3.「controllers/api/message_controller.rb」において、未表示の投稿がある場合に限り、変数@messageを作成するコードを記述。
 4.「views/api/messages/index.json.jbuilder」において、未表示の投稿の内容をjson形式に変換するコードの記述。
 5. 「assets/javascripts/message.js」において、未表示の投稿のHTMLを追加表示し、また７秒おきにリロードを実行するコードを記述。

# why
メッセージ画面を自動的に更新することで、非同期通信のままでも、
自分以外のユーザーが送信したメッセージを追加表示できるようにするため。